### PR TITLE
Add Windows installer and WinGet publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release Windows package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag, for example v0.1.0
+        required: true
+        type: string
+      publish_winget:
+        description: Submit a WinGet update after uploading the installer
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve and verify version
+        id: version
+        shell: pwsh
+        run: |
+          $tag = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ inputs.tag }}' } else { '${{ github.ref_name }}' }
+          if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$') {
+            throw "Release tag '$tag' must use the vX.Y.Z format."
+          }
+
+          $cargoManifest = Get-Content -LiteralPath 'Cargo.toml' -Raw
+          $cargoVersion = [regex]::Match($cargoManifest, '(?m)^version\s*=\s*"([^"]+)"').Groups[1].Value
+          if ($cargoVersion -ne $Matches.version) {
+            throw "Tag version '$($Matches.version)' does not match Cargo.toml version '$cargoVersion'."
+          }
+
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+          "version=$cargoVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Install Inno Setup
+        run: choco install innosetup --yes --no-progress
+
+      - name: Build ZIP and installer
+        shell: pwsh
+        run: .\scripts\package-windows.ps1
+
+      - name: Create or update GitHub release
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $tag = '${{ steps.version.outputs.tag }}'
+          $assets = @(
+            "dist/Lilo-$version-windows-x64.zip",
+            "dist/Lilo-$version-windows-x64.zip.sha256",
+            "dist/Lilo-$version-windows-x64-setup.exe",
+            "dist/Lilo-$version-windows-x64-setup.exe.sha256"
+          )
+
+          gh release view $tag *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag @assets --clobber
+          }
+          else {
+            gh release create $tag @assets --title "Lilo $version" --generate-notes --verify-tag
+          }
+          if ($LASTEXITCODE -ne 0) {
+            throw 'GitHub release publishing failed.'
+          }
+
+      - name: Download WinGetCreate
+        if: ${{ env.WINGET_GITHUB_TOKEN != '' && (github.event_name == 'push' || inputs.publish_winget) }}
+        shell: pwsh
+        run: Invoke-WebRequest 'https://aka.ms/wingetcreate/latest' -OutFile "$env:RUNNER_TEMP\wingetcreate.exe"
+
+      - name: Submit WinGet update
+        if: ${{ env.WINGET_GITHUB_TOKEN != '' && (github.event_name == 'push' || inputs.publish_winget) }}
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $tag = '${{ steps.version.outputs.tag }}'
+          $installerUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/Lilo-$version-windows-x64-setup.exe"
+          $releaseNotesUrl = "https://github.com/${{ github.repository }}/releases/tag/$tag"
+
+          & "$env:RUNNER_TEMP\wingetcreate.exe" update HellterEnjoy.Lilo `
+            --version $version `
+            --urls $installerUrl `
+            --release-notes-url $releaseNotesUrl `
+            --submit `
+            --token $env:WINGET_GITHUB_TOKEN `
+            --no-open
+          if ($LASTEXITCODE -ne 0) {
+            throw "WinGet submission failed with exit code $LASTEXITCODE."
+          }
+
+      - name: Explain skipped WinGet submission
+        if: ${{ env.WINGET_GITHUB_TOKEN == '' && (github.event_name == 'push' || inputs.publish_winget) }}
+        shell: pwsh
+        run: Write-Warning 'WINGET_GITHUB_TOKEN is not configured; release assets were published, but WinGet was not updated.'

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,53 @@
+name: Retry WinGet submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version without the v prefix, for example 0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    runs-on: windows-latest
+    env:
+      WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+    steps:
+      - name: Require submission token
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_GITHUB_TOKEN)) {
+            throw 'Add a WINGET_GITHUB_TOKEN repository secret before running this workflow.'
+          }
+
+      - name: Download WinGetCreate
+        shell: pwsh
+        run: Invoke-WebRequest 'https://aka.ms/wingetcreate/latest' -OutFile "$env:RUNNER_TEMP\wingetcreate.exe"
+
+      - name: Submit WinGet update
+        shell: pwsh
+        run: |
+          $version = '${{ inputs.version }}'
+          if ($version -notmatch '^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+            throw "Version '$version' is invalid. Pass it without the v prefix."
+          }
+
+          $tag = "v$version"
+          $installerUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/Lilo-$version-windows-x64-setup.exe"
+          $releaseNotesUrl = "https://github.com/${{ github.repository }}/releases/tag/$tag"
+
+          & "$env:RUNNER_TEMP\wingetcreate.exe" update HellterEnjoy.Lilo `
+            --version $version `
+            --urls $installerUrl `
+            --release-notes-url $releaseNotesUrl `
+            --submit `
+            --token $env:WINGET_GITHUB_TOKEN `
+            --no-open
+          if ($LASTEXITCODE -ne 0) {
+            throw "WinGet submission failed with exit code $LASTEXITCODE."
+          }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ The vault location can be changed immediately in Settings. Because notes are reg
 
 ## Installing on Windows
 
-Download the `Lilo-0.1.0-windows-x64.zip` archive from [GitHub Releases](https://github.com/HellterEnjoy/Lilo/releases), verify its SHA-256 file if desired, extract the archive and run `Lilo.exe`. The preview binary is not code-signed, so Windows SmartScreen may display a warning.
+After the package has been accepted into the WinGet community repository, install or update Lilo with:
+
+```powershell
+winget install --id HellterEnjoy.Lilo --exact
+winget upgrade --id HellterEnjoy.Lilo --exact
+```
+
+Alternatively, download `Lilo-0.1.0-windows-x64-setup.exe` from [GitHub Releases](https://github.com/HellterEnjoy/Lilo/releases). The installer does not require administrator access and creates a Start menu shortcut. A ZIP archive remains available for portable use. The preview binary is not code-signed, so Windows SmartScreen may display a warning.
 
 Updates do not require changing the vault: close Lilo and replace the extracted application files. See [RELEASE.md](RELEASE.md) for installation, updating, export and recovery instructions.
 
@@ -93,7 +100,7 @@ cargo test
 cargo clippy --all-targets -- -D warnings
 ```
 
-On Windows, create the distributable ZIP and SHA-256 checksum with:
+On Windows, install [Inno Setup 6](https://jrsoftware.org/isinfo.php), then create the installer, portable ZIP, and SHA-256 checksums with:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\package-windows.ps1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,19 @@
 
 ## Install on Windows
 
-1. Download `Lilo-<version>-windows-x64.zip` from the GitHub release.
-2. Optionally verify the archive against the accompanying `.sha256` file.
-3. Extract the complete archive to a directory owned by your Windows account.
-4. Run `Lilo.exe`. Windows SmartScreen may warn because the preview binary is not code-signed.
+The preferred installation method is WinGet:
+
+```powershell
+winget install --id HellterEnjoy.Lilo --exact
+```
+
+Until the initial package is accepted by the WinGet community repository, or for a manual installation, download `Lilo-<version>-windows-x64-setup.exe` from the GitHub release and run it. The installer is per-user and does not require administrator access. The ZIP archive remains available as a portable build. Windows SmartScreen may warn because the preview binary is not code-signed.
 
 Lilo creates its default vault as `LiloVault` in the user's Documents directory. The active path is visible and can be changed immediately in **Settings → Storage**.
 
 ## Update
 
-Close Lilo, extract the new archive, and replace the old application files. The executable is separate from the vault, so replacing it does not remove notes or settings. Keep a vault export before an update when the data matters.
+Update a WinGet installation with `winget upgrade --id HellterEnjoy.Lilo --exact`, or run the newer Setup.exe over the existing installation. Portable users can still replace the files from the newer ZIP. The executable is separate from the vault, so updating or uninstalling the application does not remove notes or settings. Keep a vault export before an update when the data matters.
 
 ## Backup and recovery
 
@@ -33,4 +36,16 @@ cargo clippy --all-targets -- -D warnings
 powershell -ExecutionPolicy Bypass -File .\scripts\package-windows.ps1
 ```
 
-The script performs a locked release build and creates the ZIP plus its SHA-256 checksum under `dist/`. Release artifacts are intentionally ignored by Git.
+The script performs a locked release build and creates the Inno Setup installer, portable ZIP, and their SHA-256 checksums under `dist/`. Release artifacts are intentionally ignored by Git.
+
+## Publishing releases and WinGet updates
+
+Pushing a `v<version>` tag runs `.github/workflows/release.yml`. The workflow verifies that the tag matches `Cargo.toml`, runs the tests, builds all Windows artifacts, and creates or updates the GitHub release.
+
+The first WinGet version must be submitted once from the checked-in manifests:
+
+```powershell
+wingetcreate submit .\winget\0.1.0 --token $env:WINGET_GITHUB_TOKEN --no-open
+```
+
+After that PR has been accepted, add a repository Actions secret named `WINGET_GITHUB_TOKEN`. It should contain a GitHub token authorized to fork and open pull requests against `microsoft/winget-pkgs`. Every later version tag will run `wingetcreate update HellterEnjoy.Lilo` automatically after the installer is uploaded. The `Retry WinGet submission` workflow can retry a failed update without rebuilding or replacing the release.

--- a/installer/Lilo.iss
+++ b/installer/Lilo.iss
@@ -1,0 +1,57 @@
+#ifndef MyAppVersion
+  #error MyAppVersion must be provided by the packaging script
+#endif
+
+#ifndef MySourceExe
+  #error MySourceExe must be provided by the packaging script
+#endif
+
+#ifndef MyOutputDir
+  #error MyOutputDir must be provided by the packaging script
+#endif
+
+#define MyAppName "Lilo"
+#define MyAppPublisher "HellterEnjoy"
+#define MyAppUrl "https://github.com/HellterEnjoy/Lilo"
+
+[Setup]
+AppId={{256F9EB3-4565-49E5-82C0-08FE0E03F6B3}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppUrl}
+AppSupportURL={#MyAppUrl}/issues
+AppUpdatesURL={#MyAppUrl}/releases
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+LicenseFile=..\LICENSE
+OutputDir={#MyOutputDir}
+OutputBaseFilename=Lilo-{#MyAppVersion}-windows-x64-setup
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+MinVersion=10.0
+UninstallDisplayIcon={app}\Lilo.exe
+CloseApplications=yes
+RestartApplications=no
+
+[Files]
+Source: "{#MySourceExe}"; DestDir: "{app}"; DestName: "Lilo.exe"; Flags: ignoreversion
+Source: "..\README.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\CHANGELOG.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\Lilo"; Filename: "{app}\Lilo.exe"
+Name: "{autodesktop}\Lilo"; Filename: "{app}\Lilo.exe"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Run]
+Filename: "{app}\Lilo.exe"; Description: "Launch Lilo"; Flags: nowait postinstall skipifsilent

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$InnoSetupPath
+)
+
 $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
@@ -13,6 +17,7 @@ $packageName = "Lilo-$version-windows-x64"
 $distRoot = Join-Path $repositoryRoot 'dist'
 $packageDirectory = Join-Path $distRoot $packageName
 $archivePath = Join-Path $distRoot "$packageName.zip"
+$installerPath = Join-Path $distRoot "Lilo-$version-windows-x64-setup.exe"
 $resolvedDistRoot = [System.IO.Path]::GetFullPath($distRoot)
 $resolvedPackageDirectory = [System.IO.Path]::GetFullPath($packageDirectory)
 if ([System.IO.Path]::GetDirectoryName($resolvedPackageDirectory) -ne $resolvedDistRoot) {
@@ -38,6 +43,9 @@ try {
     if (Test-Path -LiteralPath $archivePath) {
         Remove-Item -LiteralPath $archivePath -Force
     }
+    if (Test-Path -LiteralPath $installerPath) {
+        Remove-Item -LiteralPath $installerPath -Force
+    }
     New-Item -ItemType Directory -Path $packageDirectory | Out-Null
 
     Copy-Item -LiteralPath $executable -Destination $packageDirectory
@@ -50,8 +58,43 @@ try {
     "$($checksum.Hash)  $([System.IO.Path]::GetFileName($archivePath))" |
         Set-Content -LiteralPath "$archivePath.sha256" -Encoding ascii
 
+    if ([string]::IsNullOrWhiteSpace($InnoSetupPath)) {
+        $isccCommand = Get-Command 'ISCC.exe' -ErrorAction SilentlyContinue
+        if ($null -ne $isccCommand) {
+            $InnoSetupPath = $isccCommand.Source
+        }
+        else {
+            $innoSetupCandidates = @(
+                'C:\Program Files (x86)\Inno Setup 6\ISCC.exe',
+                (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe')
+            )
+            $InnoSetupPath = $innoSetupCandidates |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                Select-Object -First 1
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $InnoSetupPath -PathType Leaf)) {
+        throw "Inno Setup 6 was not found. Install it with 'winget install JRSoftware.InnoSetup' or pass -InnoSetupPath."
+    }
+
+    $innoScript = Join-Path $repositoryRoot 'installer\Lilo.iss'
+    & $InnoSetupPath "/DMyAppVersion=$version" "/DMySourceExe=$executable" "/DMyOutputDir=$distRoot" $innoScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "Inno Setup failed with exit code $LASTEXITCODE."
+    }
+    if (-not (Test-Path -LiteralPath $installerPath -PathType Leaf)) {
+        throw 'Inno Setup did not produce the expected installer.'
+    }
+
+    $installerChecksum = Get-FileHash -LiteralPath $installerPath -Algorithm SHA256
+    "$($installerChecksum.Hash)  $([System.IO.Path]::GetFileName($installerPath))" |
+        Set-Content -LiteralPath "$installerPath.sha256" -Encoding ascii
+
     Write-Host "Created $archivePath"
     Write-Host "SHA256: $($checksum.Hash)"
+    Write-Host "Created $installerPath"
+    Write-Host "SHA256: $($installerChecksum.Hash)"
 }
 finally {
     Pop-Location

--- a/winget/0.1.0/HellterEnjoy.Lilo.installer.yaml
+++ b/winget/0.1.0/HellterEnjoy.Lilo.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: HellterEnjoy.Lilo
+PackageVersion: 0.1.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-15
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/HellterEnjoy/Lilo/releases/download/v0.1.0/Lilo-0.1.0-windows-x64-setup.exe
+    InstallerSha256: CE4BA0F44AFF8C17F3B38776A6912843DC6D60167B54243F8FE16BEEEC95C4B0
+    ProductCode: "{256F9EB3-4565-49E5-82C0-08FE0E03F6B3}_is1"
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/winget/0.1.0/HellterEnjoy.Lilo.locale.en-US.yaml
+++ b/winget/0.1.0/HellterEnjoy.Lilo.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: HellterEnjoy.Lilo
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: HellterEnjoy
+PublisherUrl: https://github.com/HellterEnjoy
+PublisherSupportUrl: https://github.com/HellterEnjoy/Lilo/issues
+PackageName: Lilo
+PackageUrl: https://github.com/HellterEnjoy/Lilo
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/HellterEnjoy/Lilo/blob/main/LICENSE
+ShortDescription: A compact Markdown note-taking widget with a built-in knowledge graph.
+Description: Lilo is a Windows-first Markdown note-taking widget with wiki links, backlinks, folders, search, recovery tools, and an interactive knowledge graph. Notes remain ordinary local Markdown files.
+Moniker: lilo
+Tags:
+  - knowledge-graph
+  - markdown
+  - notes
+  - note-taking
+  - wiki
+ReleaseNotesUrl: https://github.com/HellterEnjoy/Lilo/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/winget/0.1.0/HellterEnjoy.Lilo.yaml
+++ b/winget/0.1.0/HellterEnjoy.Lilo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: HellterEnjoy.Lilo
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## What changed

- added a per-user Inno Setup installer while retaining the portable ZIP
- added tag-driven Windows release packaging and WinGetCreate update automation
- checked in the initial WinGet manifest and documented installation and release steps

## Why

A real installer gives Windows users Start menu integration, standard uninstall support, and reliable upgrades through WinGet instead of requiring manual ZIP extraction.

## Validation

- `cargo fmt -- --check`
- `cargo test --locked` (43 tests)
- `cargo clippy --all-targets --locked -- -D warnings`
- `winget validate --manifest .\winget\0.1.0`
- silent installer install/uninstall smoke test
- `actionlint` for both GitHub Actions workflows